### PR TITLE
feat: #2 라우트 설정 + 기본 페이지 레이아웃 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,18 @@
+import { styled } from 'styled-components'
+
+import PageRouter from './pages/PageRouter'
+
 function App() {
-  return <div className="App">App</div>
+  return (
+    <CommonLayout>
+      <PageRouter />
+    </CommonLayout>
+  )
 }
+
+const CommonLayout = styled.div`
+  width: 100%;
+  height: 100vh;
+`
 
 export default App

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -1,3 +1,16 @@
 import axios from 'axios'
 
-export const axiosInstance = axios.create({})
+const BASE_URL = 'https://www.pre-onboarding-selection-task.shop/'
+
+export const NoAuthInstance = axios.create({ 
+  baseURL: BASE_URL, 
+  headers: { "Content-Type": "application/json" } 
+})
+
+export const AuthInstance = axios.create({
+  baseURL: BASE_URL, 
+  headers: { 
+    "Content-Type": "application/json", 
+    Authorization: `Bearer ${localStorage.getItem('access_token')}`
+  }
+})

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,78 @@
+import { useNavigate } from 'react-router-dom'
+import { css, styled } from 'styled-components'
+
 function Home() {
-  return <div>Home</div>
+  const navigate = useNavigate()
+
+  return (
+    <StyledHome>
+      소개글~
+      <ButtonWrapper>
+        <Button
+          isSignin={false}
+          onClick={() => {
+            navigate('/signup')
+          }}
+        >
+          회원가입
+        </Button>
+        <Button
+          isSignin={true}
+          onClick={() => {
+            navigate('/signin')
+          }}
+        >
+          로그인
+        </Button>
+
+        <Button
+          isSignin={true}
+          onClick={() => {
+            navigate('/todo')
+          }}
+        >
+          투두 테스트 버튼
+        </Button>
+      </ButtonWrapper>
+    </StyledHome>
+  )
 }
+
+const StyledHome = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  gap: 20px;
+
+  width: 100%;
+  height: 100vh;
+`
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  gap: 10px;
+
+  width: 100%;
+`
+
+const Button = styled.button<{ isSignin: boolean }>`
+  width: 100%;
+  height: 32px;
+  max-width: 425px;
+
+  cursor: pointer;
+
+  border: 1px solid gray;
+  border-radius: 5px;
+
+  ${({ isSignin }) => css`
+    background-color: ${isSignin ? 'black' : 'white'};
+    color: ${isSignin ? 'white' : 'black'};
+  `}
+`
 
 export default Home

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -24,7 +24,6 @@ function Home() {
         >
           로그인
         </SignButton>
-
         <SignButton
           isSignin={true}
           onClick={() => {
@@ -44,7 +43,6 @@ const StyledHome = styled.div`
   align-items: center;
   flex-direction: column;
   gap: 20px;
-
   width: 100%;
   height: 100vh;
 `
@@ -55,7 +53,6 @@ const ButtonWrapper = styled.div`
   align-items: center;
   flex-direction: column;
   gap: 10px;
-
   width: 100%;
 `
 
@@ -63,11 +60,9 @@ const SignButton = styled.button<{ isSignin: boolean }>`
   width: 100%;
   height: 32px;
   max-width: 425px;
-
-  cursor: pointer;
-
   border: 1px solid gray;
   border-radius: 5px;
+  cursor: pointer;
 
   ${({ isSignin }) => css`
     background-color: ${isSignin ? 'black' : 'white'};

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -8,31 +8,31 @@ function Home() {
     <StyledHome>
       소개글~
       <ButtonWrapper>
-        <Button
+        <SignButton
           isSignin={false}
           onClick={() => {
             navigate('/signup')
           }}
         >
           회원가입
-        </Button>
-        <Button
+        </SignButton>
+        <SignButton
           isSignin={true}
           onClick={() => {
             navigate('/signin')
           }}
         >
           로그인
-        </Button>
+        </SignButton>
 
-        <Button
+        <SignButton
           isSignin={true}
           onClick={() => {
             navigate('/todo')
           }}
         >
           투두 테스트 버튼
-        </Button>
+        </SignButton>
       </ButtonWrapper>
     </StyledHome>
   )
@@ -59,7 +59,7 @@ const ButtonWrapper = styled.div`
   width: 100%;
 `
 
-const Button = styled.button<{ isSignin: boolean }>`
+const SignButton = styled.button<{ isSignin: boolean }>`
   width: 100%;
   height: 32px;
   max-width: 425px;

--- a/src/pages/PageRouter.tsx
+++ b/src/pages/PageRouter.tsx
@@ -1,0 +1,34 @@
+import { Navigate, Route, BrowserRouter, Routes } from 'react-router-dom'
+
+import Home from './Home'
+import Todo from './Todo'
+import Signin from './Signin'
+import Signup from './Signup'
+
+interface IPublicRoute {
+  isSignIn: boolean
+}
+
+function PageRouter() {
+  const isAuth = localStorage.getItem('access_token')
+
+  function ProtectedRoute() {
+    return isAuth ? <Todo /> : <Navigate to="/signin" />
+  }
+  function PublicRoute({ isSignIn }: IPublicRoute) {
+    return isAuth ? <Navigate to="/todo" /> : isSignIn ? <Signin /> : <Signup />
+  }
+
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route index element={<Home />} />
+        <Route path="/todo" element={<ProtectedRoute />} />
+        <Route path="/signin" element={<PublicRoute isSignIn={true} />} />
+        <Route path="/signup" element={<PublicRoute isSignIn={false} />} />
+      </Routes>
+    </BrowserRouter>
+  )
+}
+
+export default PageRouter

--- a/src/pages/PageRouter.tsx
+++ b/src/pages/PageRouter.tsx
@@ -5,7 +5,7 @@ import Todo from './Todo'
 import Signin from './Signin'
 import Signup from './Signup'
 
-interface IPublicRoute {
+interface PublicRouteProps {
   isSignIn: boolean
 }
 
@@ -15,7 +15,7 @@ function PageRouter() {
   function ProtectedRoute() {
     return isAuth ? <Todo /> : <Navigate to="/signin" />
   }
-  function PublicRoute({ isSignIn }: IPublicRoute) {
+  function PublicRoute({ isSignIn }: PublicRouteProps) {
     return isAuth ? <Navigate to="/todo" /> : isSignIn ? <Signin /> : <Signup />
   }
 

--- a/src/pages/PageRouter.tsx
+++ b/src/pages/PageRouter.tsx
@@ -5,27 +5,49 @@ import Todo from './Todo'
 import Signin from './Signin'
 import Signup from './Signup'
 
-interface PublicRouteProps {
-  isSignIn: boolean
+interface RouteProps {
+  isAuth: string | null
+  children: JSX.Element
+}
+
+function ProtectedRoute({ isAuth, children }: RouteProps) {
+  return isAuth ? children : <Navigate to="/signin" replace />
+}
+function PublicRoute({ isAuth, children }: RouteProps) {
+  return isAuth ? <Navigate to="/todo" replace /> : children
 }
 
 function PageRouter() {
   const isAuth = localStorage.getItem('access_token')
 
-  function ProtectedRoute() {
-    return isAuth ? <Todo /> : <Navigate to="/signin" />
-  }
-  function PublicRoute({ isSignIn }: PublicRouteProps) {
-    return isAuth ? <Navigate to="/todo" /> : isSignIn ? <Signin /> : <Signup />
-  }
-
   return (
     <BrowserRouter>
       <Routes>
         <Route index element={<Home />} />
-        <Route path="/todo" element={<ProtectedRoute />} />
-        <Route path="/signin" element={<PublicRoute isSignIn={true} />} />
-        <Route path="/signup" element={<PublicRoute isSignIn={false} />} />
+        <Route
+          path="/todo"
+          element={
+            <ProtectedRoute isAuth={isAuth}>
+              <Todo />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/signin"
+          element={
+            <PublicRoute isAuth={isAuth}>
+              <Signin />
+            </PublicRoute>
+          }
+        />
+        <Route
+          path="/signup"
+          element={
+            <PublicRoute isAuth={isAuth}>
+              <Signup />
+            </PublicRoute>
+          }
+        />
       </Routes>
     </BrowserRouter>
   )

--- a/src/pages/PageRouter.tsx
+++ b/src/pages/PageRouter.tsx
@@ -7,14 +7,15 @@ import Signup from './Signup'
 
 interface RouteProps {
   isAuth: string | null
+  fallback: string
   children: JSX.Element
 }
 
-function ProtectedRoute({ isAuth, children }: RouteProps) {
-  return isAuth ? children : <Navigate to="/signin" replace />
+function ProtectedRoute({ isAuth, fallback, children }: RouteProps) {
+  return isAuth ? children : <Navigate to={fallback} replace />
 }
-function PublicRoute({ isAuth, children }: RouteProps) {
-  return isAuth ? <Navigate to="/todo" replace /> : children
+function PublicRoute({ isAuth, fallback, children }: RouteProps) {
+  return isAuth ? <Navigate to={fallback} replace /> : children
 }
 
 function PageRouter() {
@@ -27,7 +28,7 @@ function PageRouter() {
         <Route
           path="/todo"
           element={
-            <ProtectedRoute isAuth={isAuth}>
+            <ProtectedRoute isAuth={isAuth} fallback="/signin">
               <Todo />
             </ProtectedRoute>
           }
@@ -35,7 +36,7 @@ function PageRouter() {
         <Route
           path="/signin"
           element={
-            <PublicRoute isAuth={isAuth}>
+            <PublicRoute isAuth={isAuth} fallback="/todo">
               <Signin />
             </PublicRoute>
           }
@@ -43,7 +44,7 @@ function PageRouter() {
         <Route
           path="/signup"
           element={
-            <PublicRoute isAuth={isAuth}>
+            <PublicRoute isAuth={isAuth} fallback="/todo">
               <Signup />
             </PublicRoute>
           }

--- a/src/pages/Signin.tsx
+++ b/src/pages/Signin.tsx
@@ -14,6 +14,14 @@ function Signin() {
       >
         홈으로
       </SampleButton>
+      <button
+        onClick={() => {
+          localStorage.setItem('access_token', '12340')
+          navigate(0)
+        }}
+      >
+        accessToken 추가
+      </button>
     </div>
   )
 }

--- a/src/pages/Signin.tsx
+++ b/src/pages/Signin.tsx
@@ -1,5 +1,30 @@
+import { useNavigate } from 'react-router-dom'
+import { styled } from 'styled-components'
+
 function Signin() {
-  return <div>Signin</div>
+  const navigate = useNavigate()
+
+  return (
+    <div>
+      로그인 페이지입니다
+      <SampleButton
+        onClick={() => {
+          navigate('/')
+        }}
+      >
+        홈으로
+      </SampleButton>
+    </div>
+  )
 }
+
+const SampleButton = styled.div`
+  width: fit-content;
+  height: fit-content;
+
+  background-color: skyblue;
+
+  cursor: pointer;
+`
 
 export default Signin

--- a/src/pages/Signin.tsx
+++ b/src/pages/Signin.tsx
@@ -21,9 +21,7 @@ function Signin() {
 const SampleButton = styled.div`
   width: fit-content;
   height: fit-content;
-
   background-color: skyblue;
-
   cursor: pointer;
 `
 

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,5 +1,30 @@
+import { useNavigate } from 'react-router-dom'
+import { styled } from 'styled-components'
+
 function Signup() {
-  return <div>Signup</div>
+  const navigate = useNavigate()
+
+  return (
+    <div>
+      회원가입 페이지입니다
+      <SampleButton
+        onClick={() => {
+          navigate('/')
+        }}
+      >
+        홈으로
+      </SampleButton>
+    </div>
+  )
 }
+
+const SampleButton = styled.div`
+  width: fit-content;
+  height: fit-content;
+
+  background-color: skyblue;
+
+  cursor: pointer;
+`
 
 export default Signup

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -21,9 +21,7 @@ function Signup() {
 const SampleButton = styled.div`
   width: fit-content;
   height: fit-content;
-
   background-color: skyblue;
-
   cursor: pointer;
 `
 

--- a/src/pages/Todo.tsx
+++ b/src/pages/Todo.tsx
@@ -1,5 +1,21 @@
+import { useNavigate } from 'react-router-dom'
+
 function Todo() {
-  return <div>투두리스트 페이지입니다.</div>
+  const navigate = useNavigate()
+
+  return (
+    <div>
+      투두리스트 페이지입니다.
+      <button
+        onClick={() => {
+          localStorage.removeItem('access_token')
+          navigate(0)
+        }}
+      >
+        accessToken 삭제
+      </button>
+    </div>
+  )
 }
 
 export default Todo

--- a/src/pages/Todo.tsx
+++ b/src/pages/Todo.tsx
@@ -1,5 +1,5 @@
 function Todo() {
-  return <div>Todo</div>
+  return <div>투두리스트 페이지입니다.</div>
 }
 
 export default Todo


### PR DESCRIPTION
# Description
라우트 설정과 기폰 페이지 레이아웃을 추가했습니다.

@SeungrokYoon 님과 함께 LiveShare로 페어 프로그래밍을 하였습니다 ~!

## Changes
- 라우터 설정을 하였습니다. 
  - pages/PageRouter 파일을 하나 만들어서 라우터를 관리했습니다.
  - ProtectRoute와 PublicRoute를 만들어서 리다이렉트를 시켰습니다.

- 기본 페이지 레이아웃을 추가했습니다.
  - Home : 제일 기본이 되는 페이지로 로그인 버튼과 회원가입 버튼을 달아두어 이동할 수 있게 했고, 라우터 테스트용으로 /todo로 이동하는 버튼을 추가로 만들었습니다.
  - 나머지 페이지에는 테스트용으로 Home으로 갈 수 있는 버튼을 달아두었습니다.


https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-1-7/assets/46989954/ce2888db-454a-4040-a9ab-44e3f5e270cb

close #2 