### PR TITLE
feat: #8 signIn, signup 기능 구현

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,0 +1,19 @@
+import { NoAuthInstance } from "./instance"
+
+export const postSignUp = (email: string, password: string) => {
+  try {
+    NoAuthInstance.post('/auth/signup', {email, password});
+  } catch (err) {
+    console.error(err);
+    throw err;
+  }
+}
+
+export const postSignin = (email: string, password: string) => {
+  try {
+    NoAuthInstance.post(`/auth/signin`, {email, password});
+  } catch (err) {
+    console.error(err);
+    throw err;
+  }
+};

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,19 +1,19 @@
-import { NoAuthInstance } from "./instance"
+import { NoAuthInstance } from './instance'
 
-export const postSignUp = async (email: string, password: string) => {
+export const postSignup = async (email: string, password: string) => {
   try {
-    return await NoAuthInstance.post('/auth/signup', {email, password});
+    return await NoAuthInstance.post('/auth/signup', { email, password })
   } catch (err) {
-    console.error(err);
-    throw err;
+    console.error(err)
+    throw err
   }
 }
 
 export const postSignin = async (email: string, password: string) => {
   try {
-    return await NoAuthInstance.post(`/auth/signin`, {email, password});
+    return await NoAuthInstance.post(`/auth/signin`, { email, password })
   } catch (err) {
-    console.error(err);
-    throw err;
+    console.error(err)
+    throw err
   }
-};
+}

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -2,7 +2,7 @@ import { NoAuthInstance } from "./instance"
 
 export const postSignUp = async (email: string, password: string) => {
   try {
-    await NoAuthInstance.post('/auth/signup', {email, password});
+    return await NoAuthInstance.post('/auth/signup', {email, password});
   } catch (err) {
     console.error(err);
     throw err;
@@ -11,7 +11,7 @@ export const postSignUp = async (email: string, password: string) => {
 
 export const postSignin = async (email: string, password: string) => {
   try {
-    await NoAuthInstance.post(`/auth/signin`, {email, password});
+    return await NoAuthInstance.post(`/auth/signin`, {email, password});
   } catch (err) {
     console.error(err);
     throw err;

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,17 +1,17 @@
 import { NoAuthInstance } from "./instance"
 
-export const postSignUp = (email: string, password: string) => {
+export const postSignUp = async (email: string, password: string) => {
   try {
-    NoAuthInstance.post('/auth/signup', {email, password});
+    await NoAuthInstance.post('/auth/signup', {email, password});
   } catch (err) {
     console.error(err);
     throw err;
   }
 }
 
-export const postSignin = (email: string, password: string) => {
+export const postSignin = async (email: string, password: string) => {
   try {
-    NoAuthInstance.post(`/auth/signin`, {email, password});
+    await NoAuthInstance.post(`/auth/signin`, {email, password});
   } catch (err) {
     console.error(err);
     throw err;

--- a/src/components/common/Sign/SignForm.styled.tsx
+++ b/src/components/common/Sign/SignForm.styled.tsx
@@ -1,0 +1,19 @@
+import styled from 'styled-components'
+
+export const StyledSignFormContainer = styled.div`
+  width: 100%;
+`
+
+export const StyledSignFormTitle = styled.div`
+  font-size: 30px;
+  text-align: center;
+`
+
+export const StyledSignFormBox = styled.div`
+  width: 50%;
+  margin: 20px auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`

--- a/src/components/common/Sign/SignForm.styled.tsx
+++ b/src/components/common/Sign/SignForm.styled.tsx
@@ -9,7 +9,7 @@ export const StyledSignFormTitle = styled.div`
   text-align: center;
 `
 
-export const StyledSignFormBox = styled.div`
+export const StyledSignFormBox = styled.form`
   width: 50%;
   margin: 20px auto;
   display: flex;

--- a/src/components/common/Sign/SignForm.tsx
+++ b/src/components/common/Sign/SignForm.tsx
@@ -4,12 +4,12 @@ import { Link, useNavigate } from 'react-router-dom'
 import { StyledSignFormContainer, StyledSignFormTitle, StyledSignFormBox } from './SignForm.styled'
 import { postSignUp, postSignin } from '../../../apis/auth'
 
-type Props = {
+interface SignFormProps {
   isSignUp: boolean
   setIsAuth: React.Dispatch<React.SetStateAction<string>>
 }
 
-function SignForm({ isSignUp, setIsAuth }: Props) {
+function SignForm({ isSignUp, setIsAuth }: SignFormProps) {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [isValidEmail, setIsValidEmail] = useState(false)

--- a/src/components/common/Sign/SignForm.tsx
+++ b/src/components/common/Sign/SignForm.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 
 import { StyledSignFormContainer, StyledSignFormTitle, StyledSignFormBox } from './SignForm.styled'
-import { postSignUp, postSignin } from '../../../apis/auth'
+import { postSignup, postSignin } from '../../../apis/auth'
 
 interface SignFormProps {
   isSignUp: boolean
@@ -34,7 +34,7 @@ function SignForm({ isSignUp, setIsAuth }: SignFormProps) {
       password: password,
     }
     if (isSignUp) {
-      postSignUp(data.email, data.password)
+      postSignup(data.email, data.password)
         .then(() => {
           alert('회원가입 완료!')
           navigate('/signin')

--- a/src/components/common/Sign/SignForm.tsx
+++ b/src/components/common/Sign/SignForm.tsx
@@ -17,16 +17,14 @@ function SignForm({ isSignUp }: Props) {
 
   const onChangeEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value
-
     setEmail(value)
-    setIsValidEmail(value.indexOf('@') !== -1)
+    setIsValidEmail(/@/.test(value))
   }
 
   const onChangePassword = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value
-
     setPassword(value)
-    setIsValidPassword(value.length >= 8)
+    setIsValidPassword(/.{8,}$/.test(value))
   }
 
   const sendData = () => {
@@ -37,6 +35,7 @@ function SignForm({ isSignUp }: Props) {
     if (isSignUp) {
       postSignUp(data.email, data.password)
         .then(() => {
+          alert('회원가입 완료!')
           navigate('/signin')
         })
         .catch((err) => {
@@ -46,9 +45,10 @@ function SignForm({ isSignUp }: Props) {
         })
     }
 
-    if (!isSignUp) {
+    if (isSignUp === false) {
       postSignin(data.email, data.password)
         .then((res) => {
+          console.log(res.data.access_token)
           localStorage.setItem('access_token', res.data.access_token)
           navigate('/todo')
         })
@@ -70,12 +70,24 @@ function SignForm({ isSignUp }: Props) {
           placeholder="이메일 주소"
           onChange={onChangeEmail}
         />
+        {isValidEmail === true ? (
+          <p>사용가능한 이메일입니다.</p>
+        ) : (
+          <p>이메일에는 @가 들어가야합니다.</p>
+        )}
+
         <input
           data-testid="password-input"
           type="password"
           placeholder="비밀번호 (8자리 이상)"
           onChange={onChangePassword}
         />
+        {isValidPassword === true ? (
+          <p>사용가능한 비밀번호입니다.</p>
+        ) : (
+          <p>비밀번호는 8자 이상으로 입력해주세요.</p>
+        )}
+
         <Link to={isSignUp ? '/signin' : '/signup'}>
           {isSignUp ? '로그인 페이지로' : '회원가입 페이지로'}
         </Link>

--- a/src/components/common/Sign/SignForm.tsx
+++ b/src/components/common/Sign/SignForm.tsx
@@ -49,7 +49,6 @@ function SignForm({ isSignUp, setIsAuth }: Props) {
     if (isSignUp === false) {
       postSignin(data.email, data.password)
         .then((res) => {
-          console.log(res.data.access_token)
           localStorage.setItem('access_token', res.data.access_token)
           setIsAuth(res.data.access_token)
           navigate('/todo')

--- a/src/components/common/Sign/SignForm.tsx
+++ b/src/components/common/Sign/SignForm.tsx
@@ -1,13 +1,9 @@
 import { useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 
+import { SignFormProps, SigninResponse } from './types'
 import { StyledSignFormContainer, StyledSignFormTitle, StyledSignFormBox } from './SignForm.styled'
 import { postSignup, postSignin } from '../../../apis/auth'
-
-interface SignFormProps {
-  isSignUp: boolean
-  setIsAuth: React.Dispatch<React.SetStateAction<string>>
-}
 
 function SignForm({ isSignUp, setIsAuth }: SignFormProps) {
   const [email, setEmail] = useState('')
@@ -48,7 +44,7 @@ function SignForm({ isSignUp, setIsAuth }: SignFormProps) {
 
     if (isSignUp === false) {
       postSignin(data.email, data.password)
-        .then((res) => {
+        .then((res: SigninResponse) => {
           localStorage.setItem('access_token', res.data.access_token)
           setIsAuth(res.data.access_token)
           navigate('/todo')

--- a/src/components/common/Sign/SignForm.tsx
+++ b/src/components/common/Sign/SignForm.tsx
@@ -6,9 +6,10 @@ import { postSignUp, postSignin } from '../../../apis/auth'
 
 type Props = {
   isSignUp: boolean
+  setIsAuth: React.Dispatch<React.SetStateAction<string>>
 }
 
-function SignForm({ isSignUp }: Props) {
+function SignForm({ isSignUp, setIsAuth }: Props) {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [isValidEmail, setIsValidEmail] = useState(false)
@@ -50,6 +51,7 @@ function SignForm({ isSignUp }: Props) {
         .then((res) => {
           console.log(res.data.access_token)
           localStorage.setItem('access_token', res.data.access_token)
+          setIsAuth(res.data.access_token)
           navigate('/todo')
         })
         .catch((err) => {
@@ -81,6 +83,7 @@ function SignForm({ isSignUp }: Props) {
           type="password"
           placeholder="비밀번호 (8자리 이상)"
           onChange={onChangePassword}
+          autoComplete="false"
         />
         {isValidPassword === true ? (
           <p>사용가능한 비밀번호입니다.</p>
@@ -91,6 +94,7 @@ function SignForm({ isSignUp }: Props) {
         <Link to={isSignUp ? '/signin' : '/signup'}>
           {isSignUp ? '로그인 페이지로' : '회원가입 페이지로'}
         </Link>
+        <Link to="/">홈으로</Link>
 
         <button
           data-testid={isSignUp ? 'signup-button' : 'signin-button'}

--- a/src/components/common/Sign/SignForm.tsx
+++ b/src/components/common/Sign/SignForm.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+
+import { StyledSignFormContainer, StyledSignFormTitle, StyledSignFormBox } from './SignForm.styled'
+import { postSignUp, postSignin } from '../../../apis/auth'
+
+type Props = {
+  isSignUp: boolean
+}
+
+function SignForm({ isSignUp }: Props) {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [isValidEmail, setIsValidEmail] = useState(false)
+  const [isValidPassword, setIsValidPassword] = useState(false)
+  const navigate = useNavigate()
+
+  const onChangeEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+
+    setEmail(value)
+    setIsValidEmail(value.indexOf('@') !== -1)
+  }
+
+  const onChangePassword = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+
+    setPassword(value)
+    setIsValidPassword(value.length >= 8)
+  }
+
+  const sendData = () => {
+    const data = {
+      email: email,
+      password: password,
+    }
+    if (isSignUp) {
+      postSignUp(data.email, data.password)
+        .then(() => {
+          navigate('/signin')
+        })
+        .catch((err) => {
+          const message = err.response.data.message
+          alert(message)
+          console.log(err)
+        })
+    }
+
+    if (!isSignUp) {
+      postSignin(data.email, data.password)
+        .then((res) => {
+          localStorage.setItem('access_token', res.data.access_token)
+          navigate('/todo')
+        })
+        .catch((err) => {
+          const message = err.response.data.message
+          alert(message)
+          console.log(err)
+        })
+    }
+  }
+
+  return (
+    <StyledSignFormContainer>
+      <StyledSignFormTitle>{isSignUp ? '회원가입' : '로그인'}</StyledSignFormTitle>
+      <StyledSignFormBox>
+        <input
+          data-testid="email-input"
+          type="email"
+          placeholder="이메일 주소"
+          onChange={onChangeEmail}
+        />
+        <input
+          data-testid="password-input"
+          type="password"
+          placeholder="비밀번호 (8자리 이상)"
+          onChange={onChangePassword}
+        />
+        <Link to={isSignUp ? '/signin' : '/signup'}>
+          {isSignUp ? '로그인 페이지로' : '회원가입 페이지로'}
+        </Link>
+
+        <button
+          data-testid={isSignUp ? 'signup-button' : 'signin-button'}
+          disabled={!(isValidEmail && isValidPassword)}
+          onClick={sendData}
+        >
+          {isSignUp ? '회원가입' : '로그인'}
+        </button>
+      </StyledSignFormBox>
+    </StyledSignFormContainer>
+  )
+}
+
+export default SignForm

--- a/src/components/common/Sign/SignForm.tsx
+++ b/src/components/common/Sign/SignForm.tsx
@@ -60,7 +60,7 @@ function SignForm({ isSignUp, setIsAuth }: SignFormProps) {
   return (
     <StyledSignFormContainer>
       <StyledSignFormTitle>{isSignUp ? '회원가입' : '로그인'}</StyledSignFormTitle>
-      <StyledSignFormBox>
+      <StyledSignFormBox noValidate>
         <input
           data-testid="email-input"
           type="email"

--- a/src/components/common/Sign/types.ts
+++ b/src/components/common/Sign/types.ts
@@ -1,0 +1,14 @@
+export interface SignFormProps {
+  isSignUp: boolean
+  setIsAuth: React.Dispatch<React.SetStateAction<string>>
+}
+
+export interface SignProps {
+  setIsAuth: React.Dispatch<React.SetStateAction<string>>
+}
+
+export interface SigninResponse {
+  data: {
+    access_token: string
+  }
+}

--- a/src/pages/PageRouter.tsx
+++ b/src/pages/PageRouter.tsx
@@ -45,7 +45,7 @@ function PageRouter() {
           path="/signin"
           element={
             <PublicRoute isAuth={isAuth} fallback="/todo">
-              <Signin />
+              <Signin setIsAuth={setIsAuth} />
             </PublicRoute>
           }
         />
@@ -53,7 +53,7 @@ function PageRouter() {
           path="/signup"
           element={
             <PublicRoute isAuth={isAuth} fallback="/todo">
-              <Signup />
+              <Signup setIsAuth={setIsAuth} />
             </PublicRoute>
           }
         />

--- a/src/pages/PageRouter.tsx
+++ b/src/pages/PageRouter.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { Navigate, Route, BrowserRouter, Routes } from 'react-router-dom'
 
 import Home from './Home'
@@ -19,7 +20,14 @@ function PublicRoute({ isAuth, fallback, children }: RouteProps) {
 }
 
 function PageRouter() {
-  const isAuth = localStorage.getItem('access_token')
+  const [isAuth, setIsAuth] = useState<string>('')
+  useEffect(() => {
+    if (!localStorage.getItem('access_token')) {
+      setIsAuth('')
+      return
+    }
+    setIsAuth(JSON.stringify(localStorage.getItem('access_token')))
+  }, [])
 
   return (
     <BrowserRouter>

--- a/src/pages/Signin.tsx
+++ b/src/pages/Signin.tsx
@@ -1,5 +1,3 @@
-import { useNavigate } from 'react-router-dom'
-import { styled } from 'styled-components'
 import SignForm from '../components/common/Sign/SignForm'
 
 type Props = {
@@ -7,8 +5,6 @@ type Props = {
 }
 
 function Signin({ setIsAuth }: Props) {
-  const navigate = useNavigate()
-
   return (
     <div>
       <SignForm isSignUp={false} setIsAuth={setIsAuth} />

--- a/src/pages/Signin.tsx
+++ b/src/pages/Signin.tsx
@@ -1,12 +1,13 @@
 import { useNavigate } from 'react-router-dom'
 import { styled } from 'styled-components'
+import SignForm from '../components/common/Sign/SignForm'
 
 function Signin() {
   const navigate = useNavigate()
 
   return (
     <div>
-      로그인 페이지입니다
+      <SignForm isSignUp={false} />
       <SampleButton
         onClick={() => {
           navigate('/')

--- a/src/pages/Signin.tsx
+++ b/src/pages/Signin.tsx
@@ -2,36 +2,18 @@ import { useNavigate } from 'react-router-dom'
 import { styled } from 'styled-components'
 import SignForm from '../components/common/Sign/SignForm'
 
-function Signin() {
+type Props = {
+  setIsAuth: React.Dispatch<React.SetStateAction<string>>
+}
+
+function Signin({ setIsAuth }: Props) {
   const navigate = useNavigate()
 
   return (
     <div>
-      <SignForm isSignUp={false} />
-      <SampleButton
-        onClick={() => {
-          navigate('/')
-        }}
-      >
-        홈으로
-      </SampleButton>
-      <button
-        onClick={() => {
-          localStorage.setItem('access_token', '12340')
-          navigate(0)
-        }}
-      >
-        accessToken 추가
-      </button>
+      <SignForm isSignUp={false} setIsAuth={setIsAuth} />
     </div>
   )
 }
-
-const SampleButton = styled.div`
-  width: fit-content;
-  height: fit-content;
-  background-color: skyblue;
-  cursor: pointer;
-`
 
 export default Signin

--- a/src/pages/Signin.tsx
+++ b/src/pages/Signin.tsx
@@ -1,10 +1,7 @@
 import SignForm from '../components/common/Sign/SignForm'
+import { SignProps } from '../components/common/Sign/types'
 
-interface SigninProps {
-  setIsAuth: React.Dispatch<React.SetStateAction<string>>
-}
-
-function Signin({ setIsAuth }: SigninProps) {
+function Signin({ setIsAuth }: SignProps) {
   return (
     <div>
       <SignForm isSignUp={false} setIsAuth={setIsAuth} />

--- a/src/pages/Signin.tsx
+++ b/src/pages/Signin.tsx
@@ -1,10 +1,10 @@
 import SignForm from '../components/common/Sign/SignForm'
 
-type Props = {
+interface SigninProps {
   setIsAuth: React.Dispatch<React.SetStateAction<string>>
 }
 
-function Signin({ setIsAuth }: Props) {
+function Signin({ setIsAuth }: SigninProps) {
   return (
     <div>
       <SignForm isSignUp={false} setIsAuth={setIsAuth} />

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,10 +1,10 @@
 import SignForm from '../components/common/Sign/SignForm'
 
-type Props = {
+interface SignupProps {
   setIsAuth: React.Dispatch<React.SetStateAction<string>>
 }
 
-function Signup({ setIsAuth }: Props) {
+function Signup({ setIsAuth }: SignupProps) {
   return (
     <div>
       <SignForm isSignUp={true} setIsAuth={setIsAuth} />

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -2,28 +2,18 @@ import { useNavigate } from 'react-router-dom'
 import { styled } from 'styled-components'
 import SignForm from '../components/common/Sign/SignForm'
 
-function Signup() {
+type Props = {
+  setIsAuth: React.Dispatch<React.SetStateAction<string>>
+}
+
+function Signup({ setIsAuth }: Props) {
   const navigate = useNavigate()
 
   return (
     <div>
-      <SignForm isSignUp={true} />
-      <SampleButton
-        onClick={() => {
-          navigate('/')
-        }}
-      >
-        홈으로
-      </SampleButton>
+      <SignForm isSignUp={true} setIsAuth={setIsAuth} />
     </div>
   )
 }
-
-const SampleButton = styled.div`
-  width: fit-content;
-  height: fit-content;
-  background-color: skyblue;
-  cursor: pointer;
-`
 
 export default Signup

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,12 +1,13 @@
 import { useNavigate } from 'react-router-dom'
 import { styled } from 'styled-components'
+import SignForm from '../components/common/Sign/SignForm'
 
 function Signup() {
   const navigate = useNavigate()
 
   return (
     <div>
-      회원가입 페이지입니다
+      <SignForm isSignUp={true} />
       <SampleButton
         onClick={() => {
           navigate('/')

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,10 +1,7 @@
 import SignForm from '../components/common/Sign/SignForm'
+import { SignProps } from '../components/common/Sign/types'
 
-interface SignupProps {
-  setIsAuth: React.Dispatch<React.SetStateAction<string>>
-}
-
-function Signup({ setIsAuth }: SignupProps) {
+function Signup({ setIsAuth }: SignProps) {
   return (
     <div>
       <SignForm isSignUp={true} setIsAuth={setIsAuth} />

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,5 +1,3 @@
-import { useNavigate } from 'react-router-dom'
-import { styled } from 'styled-components'
 import SignForm from '../components/common/Sign/SignForm'
 
 type Props = {
@@ -7,8 +5,6 @@ type Props = {
 }
 
 function Signup({ setIsAuth }: Props) {
-  const navigate = useNavigate()
-
   return (
     <div>
       <SignForm isSignUp={true} setIsAuth={setIsAuth} />


### PR DESCRIPTION
# Description

- @JangHyunjeong 님과 함께 LiveShare로 페어 프로그래밍하여 진행했습니다
- Signup / Signin 기능을 구현했습니다.

# Changes
- Signup / Singin에 필요한 api를 작성했습니다. 
  - [src/apis/](https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-1-7/tree/feat/%237-todo/src/apis) 경로에 [auth.ts](https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-1-7/blob/feat/%237-todo/src/apis/auth.ts)를 작성하였습니다.

- Signup / Singin 에서 공통으로 사용하는 `SignForm.tsx` 컴포넌트를 생성하여 적용했습니다. 
  - 여러페이지에서 사용하는 공통 컴포넌트라 판단되어[/src/components/common/](https://pre-onboarding-12th-1-7/src/components/common/Sign) 하위에 파일 생성했습니다.
  - `Sign 컴포넌트`로 들어오는 `isSignUp` 값에 따라 /signup /signin 페이지로 분기 처리됩니다. 
![image](https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-1-7/assets/85441226/681d7621-9591-4ffd-8b20-b6915ee41568)


- [/PageRouter.tsx](https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-1-7/blob/feat/%237-todo/src/pages/PageRouter.tsx) 에 `setIsAuth` 를 props 로 전달하여, 로그인 시, Auth에 토큰을 저장해주었습니다
![image](https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-1-7/assets/85441226/347290b3-df8a-4060-adec-4a1de9f6e4ae)

- 데모 화면
![로그인_회원가입_구현](https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-1-7/assets/85441226/92b26695-a7e7-4594-adb3-a789e09458e5)

# Additional corrections
- 좋은 api 구조에 대해 논의 후 수정 예정