### PR TITLE
style: #23 컴포넌트 스타일링 - sigin/signup

### DIFF
--- a/src/components/common/Sign/SignForm.styled.tsx
+++ b/src/components/common/Sign/SignForm.styled.tsx
@@ -14,7 +14,7 @@ export const StyledSignFormTitle = styled.div`
 `
 
 export const StyledSignFormBox = styled.form`
-  displat: block;
+  display: block;
 `
 
 export const StyledSignFormInput = styled.input`
@@ -37,7 +37,7 @@ export const StyledSignFormMsg = styled.p`
   }
 `
 export const StyledSignFormButton = styled.button`
-  dispay: block;
+  display: block;
   margin-top: 30px;
   width: 100%;
   height: 40px;

--- a/src/components/common/Sign/SignForm.styled.tsx
+++ b/src/components/common/Sign/SignForm.styled.tsx
@@ -1,19 +1,67 @@
 import styled from 'styled-components'
 
 export const StyledSignFormContainer = styled.div`
-  width: 100%;
+  width: calc(100% - 40px);
+  max-width: 500px;
+  padding-top: 100px;
+  margin: 0 auto;
 `
 
 export const StyledSignFormTitle = styled.div`
+  margin-bottom: 30px;
   font-size: 30px;
   text-align: center;
 `
 
 export const StyledSignFormBox = styled.form`
-  width: 50%;
-  margin: 20px auto;
+  displat: block;
+`
+
+export const StyledSignFormInput = styled.input`
+  display: block;
+  width: 100%;
+  height: 40px;
+  margin: 20px 0 0;
+  padding: 0 10px;
+  border: 1px solid #ddd;
+  background-color: #fff;
+`
+export const StyledSignFormMsg = styled.p`
+  font-size: 13px;
+  padding: 0;
+  margin: 10px 0 0;
+  color: red;
+
+  &.pass {
+    color: blue;
+  }
+`
+export const StyledSignFormButton = styled.button`
+  dispay: block;
+  margin-top: 30px;
+  width: 100%;
+  height: 40px;
+  background-color: blue;
+  color: white;
+  border: 0;
+  font-size: 16px;
+
+  &:disabled {
+    background-color: darkgray;
+  }
+`
+
+export const StyledSignFormLinkWrap = styled.div`
   display: flex;
-  flex-direction: column;
   justify-content: center;
-  align-items: center;
+  margin-top: 30px;
+
+  a {
+    display: block;
+    margin: 0 10px;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
 `

--- a/src/components/common/Sign/SignForm.tsx
+++ b/src/components/common/Sign/SignForm.tsx
@@ -2,7 +2,15 @@ import { useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 
 import { SignFormProps, SigninResponse } from './types'
-import { StyledSignFormContainer, StyledSignFormTitle, StyledSignFormBox } from './SignForm.styled'
+import {
+  StyledSignFormContainer,
+  StyledSignFormTitle,
+  StyledSignFormBox,
+  StyledSignFormInput,
+  StyledSignFormMsg,
+  StyledSignFormLinkWrap,
+  StyledSignFormButton,
+} from './SignForm.styled'
 import { postSignup, postSignin } from '../../../apis/auth'
 
 function SignForm({ isSignUp, setToken }: SignFormProps) {
@@ -61,19 +69,19 @@ function SignForm({ isSignUp, setToken }: SignFormProps) {
     <StyledSignFormContainer>
       <StyledSignFormTitle>{isSignUp ? '회원가입' : '로그인'}</StyledSignFormTitle>
       <StyledSignFormBox noValidate>
-        <input
+        <StyledSignFormInput
           data-testid="email-input"
           type="email"
           placeholder="이메일 주소"
           onChange={onChangeEmail}
         />
         {isValidEmail === true ? (
-          <p>사용가능한 이메일입니다.</p>
+          <StyledSignFormMsg className="pass">사용가능한 이메일입니다.</StyledSignFormMsg>
         ) : (
-          <p>이메일에는 @가 들어가야합니다.</p>
+          <StyledSignFormMsg>이메일에는 @가 들어가야합니다.</StyledSignFormMsg>
         )}
 
-        <input
+        <StyledSignFormInput
           data-testid="password-input"
           type="password"
           placeholder="비밀번호 (8자리 이상)"
@@ -81,23 +89,25 @@ function SignForm({ isSignUp, setToken }: SignFormProps) {
           autoComplete="false"
         />
         {isValidPassword === true ? (
-          <p>사용가능한 비밀번호입니다.</p>
+          <StyledSignFormMsg className="pass">사용가능한 비밀번호입니다.</StyledSignFormMsg>
         ) : (
-          <p>비밀번호는 8자 이상으로 입력해주세요.</p>
+          <StyledSignFormMsg>비밀번호는 8자 이상으로 입력해주세요.</StyledSignFormMsg>
         )}
 
-        <Link to={isSignUp ? '/signin' : '/signup'}>
-          {isSignUp ? '로그인 페이지로' : '회원가입 페이지로'}
-        </Link>
-        <Link to="/">홈으로</Link>
-
-        <button
+        <StyledSignFormButton
           data-testid={isSignUp ? 'signup-button' : 'signin-button'}
           disabled={!(isValidEmail && isValidPassword)}
           onClick={sendData}
         >
           {isSignUp ? '회원가입' : '로그인'}
-        </button>
+        </StyledSignFormButton>
+
+        <StyledSignFormLinkWrap>
+          <Link to={isSignUp ? '/signin' : '/signup'}>
+            {isSignUp ? '로그인 페이지로' : '회원가입 페이지로'}
+          </Link>
+          <Link to="/">홈으로</Link>
+        </StyledSignFormLinkWrap>
       </StyledSignFormBox>
     </StyledSignFormContainer>
   )


### PR DESCRIPTION
# Description
- sigin/signup 페이지의 컴포넌트 스타일 추가했습니다.
- 작업중인 GlobalStyle을 참고하여, 하단 스타일은 제외하고 적용해 주었습니다. 
```
 *{
    margin:0;
    padding:0;
    box-sizing: border-box;
  }
a{
    color: inherit;
    text-decoration: none;
  }
 }
 ```

# Changes

- 적용화면 (input width는 GlobalStyle적용 시, 버튼사이즈와 같게 조절됩니다. )
- 유효성 인증 전
![image](https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-1-7/assets/85441226/1670fb9d-310e-4f7d-a90a-9f154c77fb03)

- 유효성 인중 후
![image](https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-1-7/assets/85441226/3ea17a7a-1195-454e-9052-2279a598fe16)
