### PR TITLE
style: #18 컴포넌트 스타일링 - Home/Todo 페이지

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,35 @@
-import { styled } from 'styled-components'
-
+import { createGlobalStyle, styled } from 'styled-components'
 import PageRouter from './pages/PageRouter'
+
+const GlobalStyle = createGlobalStyle`
+  *{
+    margin:0;
+    padding:0;
+    box-sizing: border-box;
+  }
+  html,body{
+    height:100%
+  }
+  #root{
+    width:100%;
+    height:100%;
+  }
+  a{
+    color: inherit;
+    text-decoration: none;
+  }
+  li{
+    list-style: none;
+  }
+  button{
+    cursor: pointer;
+  }
+`
 
 function App() {
   return (
     <CommonLayout>
+      <GlobalStyle />
       <PageRouter />
     </CommonLayout>
   )
@@ -12,7 +37,7 @@ function App() {
 
 const CommonLayout = styled.div`
   width: 100%;
-  height: 100vh;
+  height: 100%;
 `
 
 export default App

--- a/src/components/TodoItem/TodoItem.tsx
+++ b/src/components/TodoItem/TodoItem.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import TodoItemProps from './types'
+import styled from 'styled-components'
 
 function TodoItem({ id, todo, isCompleted, updateTodo, deleteTodo }: TodoItemProps) {
   const [todoCheck, setTodoCheck] = useState(isCompleted)
@@ -41,41 +42,87 @@ function TodoItem({ id, todo, isCompleted, updateTodo, deleteTodo }: TodoItemPro
   }
 
   return (
-    <li>
-      <label>
-        <input type="checkbox" checked={todoCheck} onChange={onTodoCheckChanged} />
-        {isEditMode ? (
-          <input
-            data-testid="modify-input"
-            type="text"
-            onChange={onTodoModifyChanged}
-            value={todoModify}
-          />
-        ) : (
-          <span>{todo}</span>
-        )}
-      </label>
+    <Li>
+      <CheckboxSpanWrapper>
+        <StyledLabel>
+          <StyledCheckbox type="checkbox" checked={todoCheck} onChange={onTodoCheckChanged} />
+          {isEditMode ? (
+            <input
+              data-testid="modify-input"
+              type="text"
+              onChange={onTodoModifyChanged}
+              value={todoModify}
+            />
+          ) : (
+            <StyledSpan>{todo}</StyledSpan>
+          )}
+        </StyledLabel>
+      </CheckboxSpanWrapper>
       {isEditMode ? (
-        <>
-          <button data-testid="submit-button" onClick={onSubmitButtonClicked}>
+        <ButtonWrapper>
+          <StyledButton data-testid="submit-button" onClick={onSubmitButtonClicked}>
             제출
-          </button>
-          <button data-testid="cancel-button" onClick={onCancelButtonClicked}>
+          </StyledButton>
+          <StyledButton data-testid="cancel-button" onClick={onCancelButtonClicked}>
             취소
-          </button>
-        </>
+          </StyledButton>
+        </ButtonWrapper>
       ) : (
-        <>
-          <button data-testid="modify-button" onClick={onEditButtonClicked}>
+        <ButtonWrapper>
+          <StyledButton data-testid="modify-button" onClick={onEditButtonClicked}>
             수정
-          </button>
-          <button data-testid="delete-button" onClick={onDeleteButtonClicked}>
+          </StyledButton>
+          <StyledButton data-testid="delete-button" onClick={onDeleteButtonClicked}>
             삭제
-          </button>
-        </>
+          </StyledButton>
+        </ButtonWrapper>
       )}
-    </li>
+    </Li>
   )
 }
 
 export default TodoItem
+
+const StyledLabel = styled.label`
+  display: flex;
+`
+
+const StyledCheckbox = styled.input`
+  margin-right: 10px;
+`
+
+const Li = styled.li`
+  display: flex;
+  padding: 10px;
+  gap: 5%;
+  justify-content: space-between;
+  align-items: center;
+  border-radius: 12px;
+  border: 2px solid black;
+`
+const CheckboxSpanWrapper = styled.div`
+  max-width: 50%;
+  flex: 1;
+`
+const ButtonWrapper = styled.div`
+  display: flex;
+  gap: 10px;
+
+  & > button {
+    flex-shrink: 0;
+  }
+`
+const StyledButton = styled.button`
+  font-size: 0.8rem;
+  padding: 2px 4px;
+  border-radius: 2px;
+`
+
+const StyledSpan = styled.p`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-break: break-all;
+  width: 100%;
+  height: 20px;
+`

--- a/src/components/TodoList/TodoList.tsx
+++ b/src/components/TodoList/TodoList.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { styled } from 'styled-components'
 
 import TodoItem from '../TodoItem/TodoItem'
 import { TodoType } from './types'
@@ -50,34 +51,81 @@ function TodoList() {
   }, [])
 
   return (
-    <div>
-      <div>
-        <label htmlFor="addTodo">
-          <input
+    <TodoListWrapper>
+      <TodoListHead>
+        <StyledLabel htmlFor="addTodo">
+          <StyledInput
             id="addTodo"
             value={newTodo}
             onChange={(e) => setNewTodo(e.target.value)}
             data-testid="new-todo-input"
           />
-        </label>
-        <button onClick={() => createTodo(newTodo)} type="button" data-testid="new-todo-add-button">
+        </StyledLabel>
+        <StyledButton
+          onClick={() => createTodo(newTodo)}
+          type="button"
+          data-testid="new-todo-add-button"
+        >
           추가
-        </button>
-      </div>
-      <ul>
-        {todos.map((todo) => (
-          <TodoItem
-            key={todo.id}
-            id={todo.id}
-            todo={todo.todo}
-            isCompleted={todo.isCompleted}
-            updateTodo={updateTodo}
-            deleteTodo={deleteTodo}
-          />
-        ))}
-      </ul>
-    </div>
+        </StyledButton>
+      </TodoListHead>
+      <TodoListBody>
+        <FlexUl>
+          {todos.map((todo) => (
+            <TodoItem
+              key={todo.id}
+              id={todo.id}
+              todo={todo.todo}
+              isCompleted={todo.isCompleted}
+              updateTodo={updateTodo}
+              deleteTodo={deleteTodo}
+            />
+          ))}
+        </FlexUl>
+      </TodoListBody>
+    </TodoListWrapper>
   )
 }
 
 export default TodoList
+
+const TodoListWrapper = styled.div`
+  width: 100%;
+`
+
+const TodoListHead = styled.div`
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+`
+const TodoListBody = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  overflow-y: auto;
+`
+
+const StyledLabel = styled.label`
+  flex-grow: 1;
+`
+
+const StyledInput = styled.input`
+  border: 1px solid #9a9a9a;
+  border-radius: 12px;
+  padding: 8px 8px;
+  margin-right: 12px;
+  width: 100%;
+`
+const StyledButton = styled.button`
+  border: 1px solid #9a9a9a;
+  border-radius: 12px;
+  padding: 8px 8px;
+`
+const FlexUl = styled.ul`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  justify-content: center;
+  gap: 10px;
+`

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom'
 import { css, styled } from 'styled-components'
+import { PageWrapper } from './PageLayout'
 
 function Home() {
   const navigate = useNavigate()
@@ -36,17 +37,6 @@ function Home() {
     </PageWrapper>
   )
 }
-
-const PageWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-direction: column;
-  gap: 20px;
-  width: 100%;
-  min-height: 100%;
-  padding: 50px;
-`
 
 const ButtonWrapper = styled.div`
   display: flex;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,8 +5,8 @@ function Home() {
   const navigate = useNavigate()
 
   return (
-    <StyledHome>
-      소개글~
+    <PageWrapper>
+      안녕하세요, 7팀의 투두리스트 프로젝트에 오신 것을 환영합니다!
       <ButtonWrapper>
         <SignButton
           isSignin={false}
@@ -30,21 +30,22 @@ function Home() {
             navigate('/todo')
           }}
         >
-          투두 테스트 버튼
+          투두리스트 구경하러 가기
         </SignButton>
       </ButtonWrapper>
-    </StyledHome>
+    </PageWrapper>
   )
 }
 
-const StyledHome = styled.div`
+const PageWrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
   flex-direction: column;
   gap: 20px;
   width: 100%;
-  height: 100vh;
+  min-height: 100%;
+  padding: 50px;
 `
 
 const ButtonWrapper = styled.div`

--- a/src/pages/PageLayout.tsx
+++ b/src/pages/PageLayout.tsx
@@ -1,0 +1,12 @@
+import styled from 'styled-components'
+
+export const PageWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  gap: 20px;
+  width: 100%;
+  min-height: 100%;
+  padding: 50px;
+`

--- a/src/pages/Todo.tsx
+++ b/src/pages/Todo.tsx
@@ -1,23 +1,35 @@
 import { useNavigate } from 'react-router-dom'
+import { styled } from 'styled-components'
 import TodoList from '../components/TodoList/TodoList'
+import { PageWrapper } from './PageLayout'
 
 function Todo() {
   const navigate = useNavigate()
 
   return (
-    <div>
-      투두리스트 페이지입니다.
-      <TodoList />
+    <PageWrapper>
+      <PageTitle>투두리스트 페이지입니다.</PageTitle>
+      <PageBody>
+        <TodoList />
+      </PageBody>
       <button
         onClick={() => {
           localStorage.removeItem('accessToken')
           navigate(0)
         }}
       >
-        accessToken 삭제
+        로그아웃
       </button>
-    </div>
+    </PageWrapper>
   )
 }
 
 export default Todo
+
+const PageTitle = styled.h1`
+  margin-bottom: 10px;
+`
+
+const PageBody = styled.section`
+  width: 80%;
+`


### PR DESCRIPTION
# Description
- `Home` 페이지의 문구를 변경했습니다.
- `Todo` 페이지 컴포넌트 레이아웃을 수정했습니다.
  - `TodoList` 컴포넌트 스타일을 수정했습니다.
  - `TodoItem` 컴포넌트 스타일을 수정했습니다.
- 공통 스타일드 컴포넌트를 별도의 파일로 분리했습니다.
- 약간의 디테일로, ellipsis 속성을 추가해, 너무 todo 문구가 길면 말줄임표가 나오도록 처리했습니다. 이 부분은 툴팁에 전체 텍스트가 나타나도록 개선해도 좋겠네요.
## Preview
![todo](https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-1-7/assets/44149596/2376257e-7d95-432f-b243-f38dc7f93b64)
