### PR TITLE
Feat/#25 로그인 후, 투두리스트 페이지에서 투두 데이터 요청 시 401에러

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,8 +1,8 @@
-import { NoAuthInstance } from './instance'
+import { Instance } from './instance'
 
 export const postSignup = async (email: string, password: string) => {
   try {
-    return await NoAuthInstance.post('/auth/signup', { email, password })
+    return await Instance.post('/auth/signup', { email, password })
   } catch (err) {
     console.error(err)
     throw err
@@ -11,7 +11,7 @@ export const postSignup = async (email: string, password: string) => {
 
 export const postSignin = async (email: string, password: string) => {
   try {
-    return await NoAuthInstance.post(`/auth/signin`, { email, password })
+    return await Instance.post(`/auth/signin`, { email, password })
   } catch (err) {
     console.error(err)
     throw err

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -2,15 +2,15 @@ import axios from 'axios'
 
 const BASE_URL = 'https://www.pre-onboarding-selection-task.shop/'
 
-export const NoAuthInstance = axios.create({
+export const Instance = axios.create({
   baseURL: BASE_URL,
   headers: { 'Content-Type': 'application/json' },
 })
 
-export const AuthInstance = axios.create({
-  baseURL: BASE_URL,
-  headers: {
-    'Content-Type': 'application/json',
-    Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
-  },
+Instance.interceptors.request.use(function (config) {
+  const token = localStorage.getItem('accessToken')
+
+  if (token != null) config.headers.Authorization = `Bearer ${token}`
+
+  return config
 })

--- a/src/apis/todo.ts
+++ b/src/apis/todo.ts
@@ -1,13 +1,13 @@
-import { AuthInstance } from './instance'
+import { Instance } from './instance'
 import { TodoType } from '../components/TodoList/types'
 
 export const createTodoRequest = async (todo: string): Promise<TodoType> => {
-  const { data } = await AuthInstance.post('/todos', { todo })
+  const { data } = await Instance.post('/todos', { todo })
   return data
 }
 
 export const getTodosRequest = async (): Promise<TodoType[]> => {
-  const { data } = await AuthInstance.get('/todos')
+  const { data } = await Instance.get('/todos')
   return data
 }
 
@@ -16,10 +16,10 @@ export const updateTodoRequest = async (
   todo: string,
   isCompleted: boolean
 ): Promise<TodoType> => {
-  const { data } = await AuthInstance.put(`/todos/${id}`, { todo, isCompleted })
+  const { data } = await Instance.put(`/todos/${id}`, { todo, isCompleted })
   return data
 }
 
 export const deleteTodoRequest = async (id: number) => {
-  return AuthInstance.delete(`/todos/${id}`)
+  return Instance.delete(`/todos/${id}`)
 }

--- a/src/components/common/Sign/SignForm.tsx
+++ b/src/components/common/Sign/SignForm.tsx
@@ -55,7 +55,6 @@ function SignForm({ isSignUp, setToken }: SignFormProps) {
         .then((res: SigninResponse) => {
           localStorage.setItem('accessToken', res.data.access_token)
           setToken(res.data.access_token)
-          navigate('/todo')
         })
         .catch((err) => {
           const message = err.response.data.message
@@ -98,6 +97,7 @@ function SignForm({ isSignUp, setToken }: SignFormProps) {
           data-testid={isSignUp ? 'signup-button' : 'signin-button'}
           disabled={!(isValidEmail && isValidPassword)}
           onClick={sendData}
+          type="button"
         >
           {isSignUp ? '회원가입' : '로그인'}
         </StyledSignFormButton>

--- a/src/components/common/Sign/types.ts
+++ b/src/components/common/Sign/types.ts
@@ -1,10 +1,10 @@
 export interface SignFormProps {
   isSignUp: boolean
-  setToken: React.Dispatch<React.SetStateAction<string>>
+  setToken: React.Dispatch<React.SetStateAction<string | null>>
 }
 
 export interface SignProps {
-  setToken: React.Dispatch<React.SetStateAction<string>>
+  setToken: React.Dispatch<React.SetStateAction<string | null>>
 }
 
 export interface SigninResponse {

--- a/src/pages/PageRouter.tsx
+++ b/src/pages/PageRouter.tsx
@@ -21,14 +21,12 @@ function PublicRoute({ token, fallback, children }: RouteProps) {
 }
 
 function PageRouter() {
-  const [token, setToken] = useState<string>('')
+  const [token, setToken] = useState<string | null>('')
 
   useEffect(() => {
-    if (!localStorage.getItem('accessToken')) {
-      setToken('')
-      return
-    }
-    setToken(JSON.stringify(localStorage.getItem('accessToken')))
+    localStorage.getItem('accessToken') !== null
+      ? setToken('')
+      : setToken(localStorage.getItem('accessToken'))
   }, [])
 
   return (


### PR DESCRIPTION
#Description

- fix : axios instance interceptors 추가
- fix : 폼 리프레쉬 문제로 button type="button" 추가
- refactor: token type 재정의


#Changes

- 로그인 클릭시, Authorization 인증 에러가 발견되었습니다. 
- `instance.ts` 에 instance를 정의할 때, `accessToken`을 localStorage에서 가져오지 못해서 발생하는 문제였습니다. 
- `Instance.interceptors.request.use`를 사용하여, 이벤트 발생 시, token을 넣어주는 방식으로 수정했습니다 .

![로그인정상](https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-1-7/assets/85441226/19f4ac1d-6daf-4ff8-84b7-b46d987f9e83)

- 로그인 클릭시 button의 default type이 submit이어서 form이 넘어가는 문제 발생 -> button type="button"으로 수정하여 해결했습니다 .

- token type을 `string ->  string | null` 타입으로 변경했습니다
