### PR TITLE
config: #31 remote에서 병합된 로컬 브랜치 일괄 삭제하는 스크립트 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "eject": "react-scripts eject",
     "postinstall": "husky install",
     "format": "prettier --cache --write .",
-    "lint": "eslint --cache ."
+    "lint": "eslint --cache .",
+    "cleanup-branches": "echo git remote prune origin && git branch -vv | grep ': gone]'| awk '{print $1}' | xargs git branch -D"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
# Description

리모트에서 병합된 추적되고 있는 브랜치들이 로컬에서도 삭제됩니다.

## 실행 방법
팀원들의 작업속도가 빨라지고, PR단위가 적절히 작아지면서 PR이 올라오는 속도가 늘었습니다.

이에 따라 로컬에 남아있는 브랜치들이 눈에 밟혔습니다. 

그래서 이 스크립트를 추가합니다. 

```
npm run cleanup-branches
```
로 실행하시면 됩니다. 
