### PR TITLE
bug: #34 /todo -> /signin, /signup 리다이렉팅

### DIFF
--- a/src/pages/PageRouter.tsx
+++ b/src/pages/PageRouter.tsx
@@ -24,9 +24,7 @@ function PageRouter() {
   const [token, setToken] = useState<string | null>('')
 
   useEffect(() => {
-    localStorage.getItem('accessToken') !== null
-      ? setToken('')
-      : setToken(localStorage.getItem('accessToken'))
+    if (localStorage.getItem('accessToken') !== null) setToken(localStorage.getItem('accessToken'))
   }, [])
 
   return (


### PR DESCRIPTION
# Description

로컬 스토리지에 토큰이 있는 상태로 /signin 또는 /signup 페이지에 접속시 /todo 경로로 리다이렉트 되지 않는 버그를 수정 하였습니다.

## Changes

```javascript
// src/pages/PageRouter.tsx

useEffect(() => {
    localStorage.getItem('accessToken') !== null
      ? setToken('')
      : setToken(localStorage.getItem('accessToken'))
}, [])
```

위와 같은 오류를

```javascript
// src/pages/PageRouter.tsx

useEffect(() => {
    if (localStorage.getItem('accessToken') !== null) setToken(localStorage.getItem('accessToken'))
}, [])
```

다음과 같이 token이 있을 경우에만 setToken 하도록 원래 의도에 맞게 수정하였습니다.
