### PR TITLE
refactor: #37 AuthProvider 를 통한 인증 상태 관리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { createGlobalStyle, styled } from 'styled-components'
 import PageRouter from './pages/PageRouter'
+import AuthProvider from './AuthProvider'
 
 const GlobalStyle = createGlobalStyle`
   *{
@@ -28,10 +29,12 @@ const GlobalStyle = createGlobalStyle`
 
 function App() {
   return (
-    <CommonLayout>
-      <GlobalStyle />
-      <PageRouter />
-    </CommonLayout>
+    <AuthProvider>
+      <CommonLayout>
+        <GlobalStyle />
+        <PageRouter />
+      </CommonLayout>
+    </AuthProvider>
   )
 }
 

--- a/src/AuthProvider.tsx
+++ b/src/AuthProvider.tsx
@@ -1,0 +1,55 @@
+import { PropsWithChildren, createContext, useContext, useEffect, useState } from 'react'
+import { TOKEN_KEY_STR } from './apis/instance'
+
+type TokenActionType = 'sign-in' | 'sign-out'
+
+interface AuthContextType {
+  token: string | null
+  updateAuth: (param: SigninType | SignoutType) => void
+}
+
+interface AuthActionType {
+  action: TokenActionType
+}
+
+interface SigninType extends AuthActionType {
+  tokenValue: string
+}
+
+type SignoutType = AuthActionType
+
+const AuthContext = createContext<AuthContextType | null>(null)
+
+function AuthProvider({ children }: PropsWithChildren) {
+  const [token, setToken] = useState<string | null>(null)
+
+  const updateAuth = (param: SigninType | SignoutType) => {
+    if (param.action === 'sign-in') {
+      localStorage.setItem(TOKEN_KEY_STR, (param as SigninType).tokenValue)
+      setToken((param as SigninType).tokenValue)
+      return
+    }
+    if (param.action === 'sign-out') {
+      localStorage.removeItem(TOKEN_KEY_STR)
+      setToken(() => null)
+      return
+    }
+  }
+
+  useEffect(() => {
+    const token = localStorage.getItem(TOKEN_KEY_STR)
+    if (token !== null) setToken(token)
+  }, [])
+
+  return <AuthContext.Provider value={{ token, updateAuth }}>{children}</AuthContext.Provider>
+}
+
+export default AuthProvider
+
+export const useAuthContext = () => {
+  const context = useContext(AuthContext)
+  if (context === null) {
+    throw new Error('Context is null!')
+  }
+  return context
+}

--- a/src/AuthProvider.tsx
+++ b/src/AuthProvider.tsx
@@ -31,7 +31,7 @@ function AuthProvider({ children }: PropsWithChildren) {
     }
     if (param.action === 'sign-out') {
       localStorage.removeItem(TOKEN_KEY_STR)
-      setToken(() => null)
+      setToken(null)
       return
     }
   }

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -1,5 +1,6 @@
 import axios from 'axios'
 
+export const TOKEN_KEY_STR = 'accessToken'
 const BASE_URL = 'https://www.pre-onboarding-selection-task.shop/'
 
 export const Instance = axios.create({
@@ -8,7 +9,7 @@ export const Instance = axios.create({
 })
 
 Instance.interceptors.request.use(function (config) {
-  const token = localStorage.getItem('accessToken')
+  const token = localStorage.getItem(TOKEN_KEY_STR)
 
   if (token != null) config.headers.Authorization = `Bearer ${token}`
 

--- a/src/components/common/Sign/SignForm.tsx
+++ b/src/components/common/Sign/SignForm.tsx
@@ -12,13 +12,15 @@ import {
   StyledSignFormButton,
 } from './SignForm.styled'
 import { postSignup, postSignin } from '../../../apis/auth'
+import { useAuthContext } from '../../../AuthProvider'
 
-function SignForm({ isSignUp, setToken }: SignFormProps) {
+function SignForm({ isSignUp }: SignFormProps) {
+  const navigate = useNavigate()
+  const { updateAuth } = useAuthContext()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [isValidEmail, setIsValidEmail] = useState(false)
   const [isValidPassword, setIsValidPassword] = useState(false)
-  const navigate = useNavigate()
 
   const onChangeEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value
@@ -46,20 +48,19 @@ function SignForm({ isSignUp, setToken }: SignFormProps) {
         .catch((err) => {
           const message = err.response.data.message
           alert(message)
-          console.log(err)
+          console.error(err)
         })
     }
 
     if (isSignUp === false) {
       postSignin(data.email, data.password)
         .then((res: SigninResponse) => {
-          localStorage.setItem('accessToken', res.data.access_token)
-          setToken(res.data.access_token)
+          updateAuth({ action: 'sign-in', tokenValue: res.data.access_token })
         })
         .catch((err) => {
           const message = err.response.data.message
           alert(message)
-          console.log(err)
+          console.error(err)
         })
     }
   }

--- a/src/components/common/Sign/types.ts
+++ b/src/components/common/Sign/types.ts
@@ -1,10 +1,5 @@
 export interface SignFormProps {
   isSignUp: boolean
-  setToken: React.Dispatch<React.SetStateAction<string | null>>
-}
-
-export interface SignProps {
-  setToken: React.Dispatch<React.SetStateAction<string | null>>
 }
 
 export interface SigninResponse {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,19 +2,16 @@ import { useNavigate } from 'react-router-dom'
 import { css, styled } from 'styled-components'
 import { PageWrapper } from './PageLayout'
 import { ReactComponent as MainIcon } from '../assets/MainIcon.svg'
+import { useAuthContext } from '../AuthProvider'
 
-interface HomeProps {
-  token: string | null
-}
-
-function Home({ token }: HomeProps) {
+function Home() {
   const navigate = useNavigate()
+  const { token, updateAuth } = useAuthContext()
   const isAuthorized = token !== null && token !== ''
 
   return (
     <PageWrapper>
       <MainIcon />
-
       {`안녕하세요 ${
         isAuthorized ? '회원님' : '손님'
       }, 7팀의 투두리스트 프로젝트에 오신 것을 환영합니다!`}
@@ -23,8 +20,7 @@ function Home({ token }: HomeProps) {
           <SignButton
             isSignin={true}
             onClick={() => {
-              localStorage.removeItem('accessToken')
-              navigate(0)
+              updateAuth({ action: 'sign-out' })
             }}
           >
             로그아웃

--- a/src/pages/PageRouter.tsx
+++ b/src/pages/PageRouter.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react'
 import { Navigate, Route, BrowserRouter, Routes } from 'react-router-dom'
 
 import Home from './Home'
@@ -6,35 +5,32 @@ import Todo from './Todo'
 import Signin from './Signin'
 import Signup from './Signup'
 import NotFound from './NotFound'
+import { useAuthContext } from '../AuthProvider'
 
 interface RouteProps {
-  token: string | null
   fallback: string
   children: JSX.Element
 }
 
-function ProtectedRoute({ token, fallback, children }: RouteProps) {
+function ProtectedRoute({ fallback, children }: RouteProps) {
+  const { token } = useAuthContext()
   return token ? children : <Navigate to={fallback} replace />
 }
-function PublicRoute({ token, fallback, children }: RouteProps) {
+
+function PublicRoute({ fallback, children }: RouteProps) {
+  const { token } = useAuthContext()
   return token ? <Navigate to={fallback} replace /> : children
 }
 
 function PageRouter() {
-  const [token, setToken] = useState<string | null>(null)
-
-  useEffect(() => {
-    if (localStorage.getItem('accessToken') !== null) setToken(localStorage.getItem('accessToken'))
-  }, [])
-
   return (
     <BrowserRouter>
       <Routes>
-        <Route index element={<Home token={token} />} />
+        <Route index element={<Home />} />
         <Route
           path="/todo"
           element={
-            <ProtectedRoute token={token} fallback="/signin">
+            <ProtectedRoute fallback="/signin">
               <Todo />
             </ProtectedRoute>
           }
@@ -42,16 +38,16 @@ function PageRouter() {
         <Route
           path="/signin"
           element={
-            <PublicRoute token={token} fallback="/todo">
-              <Signin setToken={setToken} />
+            <PublicRoute fallback="/todo">
+              <Signin />
             </PublicRoute>
           }
         />
         <Route
           path="/signup"
           element={
-            <PublicRoute token={token} fallback="/todo">
-              <Signup setToken={setToken} />
+            <PublicRoute fallback="/todo">
+              <Signup />
             </PublicRoute>
           }
         />

--- a/src/pages/Signin.tsx
+++ b/src/pages/Signin.tsx
@@ -1,10 +1,9 @@
 import SignForm from '../components/common/Sign/SignForm'
-import { SignProps } from '../components/common/Sign/types'
 
-function Signin({ setToken }: SignProps) {
+function Signin() {
   return (
     <div>
-      <SignForm isSignUp={false} setToken={setToken} />
+      <SignForm isSignUp={false} />
     </div>
   )
 }

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,10 +1,9 @@
 import SignForm from '../components/common/Sign/SignForm'
-import { SignProps } from '../components/common/Sign/types'
 
-function Signup({ setToken }: SignProps) {
+function Signup() {
   return (
     <div>
-      <SignForm isSignUp={true} setToken={setToken} />
+      <SignForm isSignUp={true} />
     </div>
   )
 }

--- a/src/pages/Todo.tsx
+++ b/src/pages/Todo.tsx
@@ -1,10 +1,10 @@
-import { useNavigate } from 'react-router-dom'
 import { styled } from 'styled-components'
 import TodoList from '../components/TodoList/TodoList'
 import { PageWrapper } from './PageLayout'
+import { useAuthContext } from '../AuthProvider'
 
 function Todo() {
-  const navigate = useNavigate()
+  const { updateAuth } = useAuthContext()
 
   return (
     <PageWrapper>
@@ -14,8 +14,7 @@ function Todo() {
       </PageBody>
       <button
         onClick={() => {
-          localStorage.removeItem('accessToken')
-          navigate(0)
+          updateAuth({ action: 'sign-out' })
         }}
       >
         로그아웃


### PR DESCRIPTION
# Description 

인증 상태를 Context API를 활용한 `AuthProvider` 에서 관리하도록 리팩토링했습니다.

## 리팩토링의 배경
- 라우터의 역할이 비대: 기존에는 `PageRouter`에서 `로그인` 여부(`Auth 데이터`로 칭하겠습니다)를 관리하고, 하위 페이지의 라우팅을 조절했습니다.
  이 방식은 페이지에 `token`, `setToken`이라는 프롭을 강제하였으며, 일관되지 않은 프롭을 페이지별로 사용했었습니다.
- 상태 업데이트 추적의 어려움: 비동기 함수 처리 후 리다이렉션과 `Auth 데이터` 수정로직이 컴포넌트와 페이지에 흩어져 있어, 문제가 발생했을 시, 상태 업데이트 로직을 추적하는 것이 어려웠습니다.
- 상수 관리의 어려움: `access_token` , `accessToken`등 리터럴로 직접 입력하면서 오타로 인한 실수 및 에러가 종종 발생했습니다.

## Changes
- localStorage를 호출하는 로직이 이제는 instance.ts와 AuthProvider에서만 호출됩니다.
- 하위 컴포넌트 및 페이지에서는 `useAuthContext`라는 커스텀 훅을 사용하여 컨텍스트 데이터를 구독할 수 있습니다.

## Preview
![refactor-authprovider](https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-1-7/assets/44149596/8e75f332-9f7e-4326-aac8-df7fc9c72e85)
