### PR TITLE
refactor: #50 SignForm 리팩토링

### DIFF
--- a/src/components/common/Sign/SignForm.tsx
+++ b/src/components/common/Sign/SignForm.tsx
@@ -1,8 +1,5 @@
 import { Link } from 'react-router-dom'
-
-import { SignFormProps } from './types'
 import {
-  StyledSignFormContainer,
   StyledSignFormTitle,
   StyledSignFormBox,
   StyledSignFormInput,
@@ -10,60 +7,107 @@ import {
   StyledSignFormLinkWrap,
   StyledSignFormButton,
 } from './SignForm.styled'
-import useForm from '../../../hooks/useForm'
+import useForm, { FormModeType } from '../../../hooks/useForm'
+import { PropsWithChildren, createContext, useContext } from 'react'
 
-function SignForm({ isSignUp }: SignFormProps) {
-  const { onChangeEmail, onChangePassword, sendData, isValidEmail, isValidPassword } = useForm({
-    isSignUp,
-  })
+interface SignFormContextType {
+  onChangeEmail: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onChangePassword: (e: React.ChangeEvent<HTMLInputElement>) => void
+  sendData: () => void
+  isValidEmail: boolean
+  isValidPassword: boolean
+}
 
+const SignFormContext = createContext<SignFormContextType | null>(null)
+
+interface SignForm extends PropsWithChildren {
+  mode: FormModeType
+}
+
+export default function SignForm({ children, mode }: SignForm) {
+  const formState = useForm(mode)
   return (
-    <StyledSignFormContainer>
-      <StyledSignFormTitle>{isSignUp ? '회원가입' : '로그인'}</StyledSignFormTitle>
-      <StyledSignFormBox noValidate>
-        <StyledSignFormInput
-          data-testid="email-input"
-          type="email"
-          placeholder="이메일 주소"
-          onChange={onChangeEmail}
-        />
-        {isValidEmail === true ? (
-          <StyledSignFormMsg className="pass">사용가능한 이메일입니다.</StyledSignFormMsg>
-        ) : (
-          <StyledSignFormMsg>이메일에는 @가 들어가야합니다.</StyledSignFormMsg>
-        )}
-
-        <StyledSignFormInput
-          data-testid="password-input"
-          type="password"
-          placeholder="비밀번호 (8자리 이상)"
-          onChange={onChangePassword}
-          autoComplete="false"
-        />
-        {isValidPassword === true ? (
-          <StyledSignFormMsg className="pass">사용가능한 비밀번호입니다.</StyledSignFormMsg>
-        ) : (
-          <StyledSignFormMsg>비밀번호는 8자 이상으로 입력해주세요.</StyledSignFormMsg>
-        )}
-
-        <StyledSignFormButton
-          data-testid={isSignUp ? 'signup-button' : 'signin-button'}
-          disabled={!(isValidEmail && isValidPassword)}
-          onClick={sendData}
-          type="button"
-        >
-          {isSignUp ? '회원가입' : '로그인'}
-        </StyledSignFormButton>
-
-        <StyledSignFormLinkWrap>
-          <Link to={isSignUp ? '/signin' : '/signup'}>
-            {isSignUp ? '로그인 페이지로' : '회원가입 페이지로'}
-          </Link>
-          <Link to="/">홈으로</Link>
-        </StyledSignFormLinkWrap>
-      </StyledSignFormBox>
-    </StyledSignFormContainer>
+    <SignFormContext.Provider value={{ ...formState }}>
+      <StyledSignFormBox noValidate>{children}</StyledSignFormBox>
+    </SignFormContext.Provider>
   )
 }
 
-export default SignForm
+function SignFormTitle({ title }: { title: string }) {
+  return <StyledSignFormTitle>{title}</StyledSignFormTitle>
+}
+
+function SignFormInputEmail() {
+  const { onChangeEmail, isValidEmail } = useFormContext()
+  return (
+    <>
+      <StyledSignFormInput
+        data-testid="email-input"
+        type="email"
+        placeholder="이메일 주소"
+        onChange={onChangeEmail}
+      />
+      {isValidEmail === true ? (
+        <StyledSignFormMsg className="pass">사용가능한 이메일입니다.</StyledSignFormMsg>
+      ) : (
+        <StyledSignFormMsg>이메일에는 @가 들어가야합니다.</StyledSignFormMsg>
+      )}
+    </>
+  )
+}
+
+function SignFormInputPassword() {
+  const { onChangePassword, isValidPassword } = useFormContext()
+  return (
+    <>
+      <StyledSignFormInput
+        data-testid="password-input"
+        type="password"
+        placeholder="비밀번호 (8자리 이상)"
+        onChange={onChangePassword}
+        autoComplete="false"
+      />
+      {isValidPassword === true ? (
+        <StyledSignFormMsg className="pass">사용가능한 비밀번호입니다.</StyledSignFormMsg>
+      ) : (
+        <StyledSignFormMsg>비밀번호는 8자 이상으로 입력해주세요.</StyledSignFormMsg>
+      )}
+    </>
+  )
+}
+
+function SignFormButtonButtonGroup({ mode }: { mode: FormModeType }) {
+  const { sendData, isValidEmail, isValidPassword } = useFormContext()
+  return (
+    <>
+      <StyledSignFormButton
+        data-testid={mode === 'signup' ? 'signup-button' : 'signin-button'}
+        disabled={!(isValidEmail && isValidPassword)}
+        onClick={sendData}
+        type="button"
+      >
+        {mode === 'signup' ? '회원가입' : '로그인'}
+      </StyledSignFormButton>
+      <StyledSignFormLinkWrap>
+        <Link to={mode === 'signup' ? '/signin' : '/signup'}>
+          {mode === 'signup' ? '로그인 페이지로' : '회원가입 페이지로'}
+        </Link>
+        <Link to="/">홈으로</Link>
+      </StyledSignFormLinkWrap>
+    </>
+  )
+}
+
+export const useFormContext = () => {
+  const context = useContext(SignFormContext)
+  if (context === null) {
+    throw Error('FormContext is null!')
+  }
+  return context
+}
+
+SignForm.Title = SignFormTitle
+SignForm.Form = SignForm
+SignForm.Id = SignFormInputEmail
+SignForm.Password = SignFormInputPassword
+SignForm.ButtonGroup = SignFormButtonButtonGroup

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -1,10 +1,12 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { SignFormProps, SigninResponse } from '../components/common/Sign/types'
+import { SigninResponse } from '../components/common/Sign/types'
 import { postSignin, postSignup } from '../apis/auth'
 import { useAuthContext } from '../AuthProvider'
 
-const useForm = ({ isSignUp }: SignFormProps) => {
+export type FormModeType = 'signin' | 'signup'
+
+const useForm = (mode: FormModeType) => {
   const navigate = useNavigate()
   const { updateAuth } = useAuthContext()
 
@@ -31,7 +33,7 @@ const useForm = ({ isSignUp }: SignFormProps) => {
       password: password,
     }
 
-    if (isSignUp) {
+    if (mode === 'signup') {
       postSignup(data.email, data.password)
         .then(() => {
           alert('회원가입 완료!')
@@ -60,7 +62,7 @@ const useForm = ({ isSignUp }: SignFormProps) => {
     sendData,
     isValidEmail,
     isValidPassword,
-  }
+  } as const
 }
 
 export default useForm

--- a/src/pages/SigninPage.tsx
+++ b/src/pages/SigninPage.tsx
@@ -1,9 +1,17 @@
 import SignForm from '../components/common/Sign/SignForm'
+import { StyledSignFormContainer } from '../components/common/Sign/SignForm.styled'
 
 function SigninPage() {
   return (
     <div>
-      <SignForm isSignUp={false} />
+      <StyledSignFormContainer>
+        <SignForm.Title title="로그인" />
+        <SignForm.Form mode="signin">
+          <SignForm.Id />
+          <SignForm.Password />
+          <SignForm.ButtonGroup mode="signin" />
+        </SignForm.Form>
+      </StyledSignFormContainer>
     </div>
   )
 }

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,9 +1,17 @@
 import SignForm from '../components/common/Sign/SignForm'
+import { StyledSignFormContainer } from '../components/common/Sign/SignForm.styled'
 
 function SignupPage() {
   return (
     <div>
-      <SignForm isSignUp={true} />
+      <StyledSignFormContainer>
+        <SignForm.Title title="회원가입" />
+        <SignForm.Form mode="signup">
+          <SignForm.Id />
+          <SignForm.Password />
+          <SignForm.ButtonGroup mode="signup" />
+        </SignForm.Form>
+      </StyledSignFormContainer>
     </div>
   )
 }


### PR DESCRIPTION
# Description

ContextAPI를 활용하여 SignForm 컴포넌트를 리팩토링 했습니다. 

Form은 하위에 많은 컴포넌트들을 가지고 있습니다. 
합성 컴포넌트를 활용하면 조금 더 컴포넌트 내부가 잘 보이고, 기능도 한 눈에 예측가능하다 생각했습니다.

아래는 리팩토링 후 페이지 컴포넌트의 컴포넌트 구조입니다.


```js
function SignupPage() {
  return (
    <div>
      <StyledSignFormContainer>
        <SignForm.Title title="회원가입" />
        <SignForm.Form mode="signup">
          <SignForm.Id />
          <SignForm.Password />
          <SignForm.ButtonGroup mode="signup" />
        </SignForm.Form>
      </StyledSignFormContainer>
    </div>
  )
}
```

```js
function SigninPage() {
  return (
    <div>
      <StyledSignFormContainer>
        <SignForm.Title title="로그인" />
        <SignForm.Form mode="signin">
          <SignForm.Id />
          <SignForm.Password />
          <SignForm.ButtonGroup mode="signin" />
        </SignForm.Form>
      </StyledSignFormContainer>
    </div>
  )
}
```


## 추가 리팩토링은...
안 쪽의 Email태그와 Password 컴포넌트가 중복되는 로직이 많습니다. 

이걸 줄이려면 Props를 활용하면 좋을 듯 싶습니다!